### PR TITLE
FIX: Added double quotes between array expansions

### DIFF
--- a/simplerisk-setup.sh
+++ b/simplerisk-setup.sh
@@ -489,7 +489,7 @@ setup(){
 	# Check to make sure we are running as root
 	check_root
 	# Ask user on how to proceed
-	validate_args ${@:1}
+	validate_args "${@:1}"
 }
 
 os_detect(){
@@ -547,4 +547,4 @@ os_detect(){
 }
 
 ## Defer setup until we have the complete script
-setup ${@:1}
+setup "${@:1}"


### PR DESCRIPTION
Regarding pull request #1, there was a low vulnerability detected by this [static scanner from ShiftLeft](https://github.com/ShiftLeftSecurity/sast-scan). 

[sast_report.pdf](https://github.com/simplerisk/setup-scripts/files/5183405/sast_report.pdf)

This is a simple fix by adding double quotes on the array expansions used on the mentioned pull request. This does not affect the functionality.