### PR TITLE
Fixes for CentOS and RHEL installation

### DIFF
--- a/simplerisk-setup.sh
+++ b/simplerisk-setup.sh
@@ -180,7 +180,7 @@ setup_centos_7(){
 	exec_cmd "rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
 	exec_cmd "rpm -Uvh http://rpms.famillecollet.com/enterprise/remi-release-7.rpm"
 	exec_cmd "yum -y --enablerepo=remi,remi-php74 install httpd php php-common"
-	exec_cmd "yum -y --enablerepo=remi,remi-php74 install php-cli php-pear php-pdo php-mysqlnd php-gd php-mbstring php-mcrypt php-xml php-curl php-ldap"
+	exec_cmd "yum -y --enablerepo=remi,remi-php74 install php-cli php-pear php-pdo php-mysqlnd php-gd php-mbstring php-xml php-curl php-ldap"
 
 	print_status "Installing mod_ssl"
 	exec_cmd "yum -y install mod_ssl"
@@ -336,7 +336,7 @@ setup_rhel_8(){
 	exec_cmd "yum -y install httpd"
 
 	print_status "Installing PHP for Apache..."
-	exec_cmd "yum -y install php php-mysqlnd php-mbstring php-opcache php-gd php-json php-ldap php-curl"
+	exec_cmd "yum -y install php php-mysqlnd php-mbstring php-opcache php-gd php-json php-ldap php-curl php-xml"
 	
 	print_status "Installing the MariaDB database server..."
 	exec_cmd "curl -sL https://downloads.mariadb.com/MariaDB/mariadb_repo_setup | bash -"

--- a/simplerisk-setup.sh
+++ b/simplerisk-setup.sh
@@ -179,8 +179,8 @@ setup_centos_7(){
 	print_status "Installing PHP for Apache..."
 	exec_cmd "rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
 	exec_cmd "rpm -Uvh http://rpms.famillecollet.com/enterprise/remi-release-7.rpm"
-	exec_cmd "yum -y --enablerepo=remi,remi-php71 install httpd php php-common"
-	exec_cmd "yum -y --enablerepo=remi,remi-php71 install php-cli php-pear php-pdo php-mysqlnd php-gd php-mbstring php-mcrypt php-xml php-curl"
+	exec_cmd "yum -y --enablerepo=remi,remi-php74 install httpd php php-common"
+	exec_cmd "yum -y --enablerepo=remi,remi-php74 install php-cli php-pear php-pdo php-mysqlnd php-gd php-mbstring php-mcrypt php-xml php-curl php-ldap"
 
 	print_status "Installing mod_ssl"
 	exec_cmd "yum -y install mod_ssl"

--- a/simplerisk-setup.sh
+++ b/simplerisk-setup.sh
@@ -204,7 +204,7 @@ setup_centos_7(){
 	print_status "Configuring Apache..."
 	exec_cmd "cd /etc/httpd && mkdir sites-available"
 	exec_cmd "cd /etc/httpd && mkdir sites-enabled"
-	exec_cmd "echo \"IncludeOptional sites-enabled/*.conf\" >> /etc/httpd/conf/httpd.conf"
+	echo "IncludeOptional sites-enabled/*.conf" >> /etc/httpd/conf/httpd.conf
 	echo "<VirtualHost *:80>" >> /etc/httpd/sites-enabled/simplerisk.conf
 	echo "  DocumentRoot \"/var/www/simplerisk/\"" >> /etc/httpd/sites-enabled/simplerisk.conf
 	echo "  ErrorLog /var/log/httpd/error_log" >> /etc/httpd/sites-enabled/simplerisk.conf
@@ -358,7 +358,7 @@ setup_rhel_8(){
 	exec_cmd "sed -i 's/#DocumentRoot \"\/var\/www\/html\"/DocumentRoot \"\/var\/www\/simplerisk\"/' /etc/httpd/conf.d/ssl.conf"
 	exec_cmd "cd /etc/httpd && mkdir sites-available"
 	exec_cmd "cd /etc/httpd && mkdir sites-enabled"
-	exec_cmd "echo \"IncludeOptional sites-enabled/*.conf\" >> /etc/httpd/conf/httpd.conf"
+	echo \"IncludeOptional sites-enabled/*.conf\" >> /etc/httpd/conf/httpd.conf
 	echo "<VirtualHost *:80>" >> /etc/httpd/sites-enabled/simplerisk.conf
 	echo "  DocumentRoot \"/var/www/simplerisk/\"" >> /etc/httpd/sites-enabled/simplerisk.conf
 	echo "  ErrorLog /var/log/httpd/error_log" >> /etc/httpd/sites-enabled/simplerisk.conf


### PR DESCRIPTION
- For CentOS specifically:
  - Using remi-php74 as repository for PHP dependencies (previously used PHP 7.1). This will solve the PHP and specially the LDAP check
  - Removing `php-mcrypt`
- Changed way to print the IncludeOptional into the httpd.conf (was not working previously)
- Adding `sql_mode` line for the installation