### PR TITLE
Using shared libraries on Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,10 +35,10 @@ pipeline {
 									}
 								}
 								aborted {
-									script { awsOps.terminateInstance("${debian_instance_id}", "us-east-1") }
+									script { awsOps.terminateInstance("${debian_instance_id}") }
 								}
 								cleanup {
-									script { awsOps.terminateInstance("${debian_instance_id}", "us-east-1") }
+									script { awsOps.terminateInstance("${debian_instance_id}", 60) }
 								}
 							}
 						}
@@ -64,10 +64,10 @@ pipeline {
 									}
 								}
 								aborted {
-									script { awsOps.terminateInstance("${debian_instance_id}", "us-east-1") }
+									script { awsOps.terminateInstance("${debian_instance_id}") }
 								}
 								cleanup {
-									script { awsOps.terminateInstance("${debian_instance_id}", "us-east-1") }
+									script { awsOps.terminateInstance("${debian_instance_id}") }
 								}
 							}
 						}
@@ -93,10 +93,10 @@ pipeline {
 									}
 								}
 								aborted {
-									script { awsOps.terminateInstance("${u18_instance_id}", "us-east-1") }
+									script { awsOps.terminateInstance("${u18_instance_id}") }
 								}
 								cleanup {
-									script { awsOps.terminateInstance("${u18_instance_id}", "us-east-1") }
+									script { awsOps.terminateInstance("${u18_instance_id}", 60) }
 								}
 							}
 						}
@@ -123,10 +123,10 @@ pipeline {
 									}
 								}
 								aborted {
-									script { awsOps.terminateInstance("${u18_instance_id}", "us-east-1") }
+									script { awsOps.terminateInstance("${u18_instance_id}") }
 								}
 								cleanup {
-									script { awsOps.terminateInstance("${u18_instance_id}", "us-east-1") }
+									script { awsOps.terminateInstance("${u18_instance_id}") }
 								}
 							}
 						}
@@ -151,10 +151,10 @@ pipeline {
 									}
 								}
 								aborted {
-									script { awsOps.terminateInstance("${u20_instance_id}", "us-east-1") }
+									script { awsOps.terminateInstance("${u20_instance_id}") }
 								}
 								cleanup {
-									script { awsOps.terminateInstance("${u20_instance_id}", "us-east-1") }
+									script { awsOps.terminateInstance("${u20_instance_id}", 60) }
 								}
 							}
 						}
@@ -180,10 +180,10 @@ pipeline {
 									}
 								}
 								aborted {
-									script { awsOps.terminateInstance("${u20_instance_id}", "us-east-1") }
+									script { awsOps.terminateInstance("${u20_instance_id}") }
 								}
 								cleanup {
-									script { awsOps.terminateInstance("${u20_instance_id}", "us-east-1") }
+									script { awsOps.terminateInstance("${u20_instance_id}") }
 								}
 							}
 						}
@@ -208,10 +208,10 @@ pipeline {
 									}
 								}
 								aborted {
-									script { awsOps.terminateInstance("${sles12_instance_id}", "us-east-1") }
+									script { awsOps.terminateInstance("${sles12_instance_id}") }
 								}
 								cleanup {
-									script { awsOps.terminateInstance("${sles12_instance_id}", "us-east-1") }
+									script { awsOps.terminateInstance("${sles12_instance_id}", 60) }
 								}
 							}
 						}
@@ -237,10 +237,10 @@ pipeline {
 									}
 								}
 								aborted {
-									script { awsOps.terminateInstance("${sles12_instance_id}", "us-east-1") }
+									script { awsOps.terminateInstance("${sles12_instance_id}") }
 								}
 								cleanup {
-									script { awsOps.terminateInstance("${sles12_instance_id}", "us-east-1") }
+									script { awsOps.terminateInstance("${sles12_instance_id}") }
 								}
 							}
 						}
@@ -265,10 +265,10 @@ pipeline {
 									}
 								}
 								aborted {
-									script { awsOps.terminateInstance("${sles15_instance_id}", "us-east-1") }
+									script { awsOps.terminateInstance("${sles15_instance_id}") }
 								}
 								cleanup {
-									script { awsOps.terminateInstance("${sles15_instance_id}", "us-east-1") }
+									script { awsOps.terminateInstance("${sles15_instance_id}", 60) }
 								}
 							}
 						}
@@ -294,10 +294,10 @@ pipeline {
 									}
 								}
 								aborted {
-									script { awsOps.terminateInstance("${sles15_instance_id}", "us-east-1") }
+									script { awsOps.terminateInstance("${sles15_instance_id}") }
 								}
 								cleanup {
-									script { awsOps.terminateInstance("${sles15_instance_id}", "us-east-1") }
+									script { awsOps.terminateInstance("${sles15_instance_id}") }
 								}
 							}
 						}
@@ -322,10 +322,10 @@ pipeline {
 									}
 								}
 								aborted {
-									script { awsOps.terminateInstance("${rhel_instance_id}", "us-east-1") }
+									script { awsOps.terminateInstance("${rhel_instance_id}") }
 								}
 								cleanup {
-									script { awsOps.terminateInstance("${rhel_instance_id}", "us-east-1") }
+									script { awsOps.terminateInstance("${rhel_instance_id}", 60) }
 								}
 							}
 						}
@@ -351,10 +351,10 @@ pipeline {
 									}
 								}
 								aborted {
-									script { awsOps.terminateInstance("${rhel_instance_id}", "us-east-1") }
+									script { awsOps.terminateInstance("${rhel_instance_id}") }
 								}
 								cleanup {
-									script { awsOps.terminateInstance("${rhel_instance_id}", "us-east-1") }
+									script { awsOps.terminateInstance("${rhel_instance_id}") }
 								}
 							}
 						}
@@ -379,10 +379,10 @@ pipeline {
 									}
 								}
 								aborted {
-									script { awsOps.terminateInstance("${centos_instance_id}", "us-east-1") }
+									script { awsOps.terminateInstance("${centos_instance_id}") }
 								}
 								cleanup {
-									script { awsOps.terminateInstance("${centos_instance_id}", "us-east-1") }
+									script { awsOps.terminateInstance("${centos_instance_id}", 60) }
 								}
 							}
 						}
@@ -408,10 +408,10 @@ pipeline {
 									}
 								}
 								aborted {
-									script { awsOps.terminateInstance("${centos_instance_id}", "us-east-1") }
+									script { awsOps.terminateInstance("${centos_instance_id}") }
 								}
 								cleanup {
-									script { awsOps.terminateInstance("${centos_instance_id}", "us-east-1") }
+									script { awsOps.terminateInstance("${centos_instance_id}") }
 								}
 							}
 						}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,8 +27,8 @@ pipeline {
 								script {
 									if (env.CHANGE_ID) { pullRequest.createStatus(status: "pending", context: "setup-scripts/debian10", description: "Installing SimpleRisk through script on server...", targetUrl: "$BUILD_URL") }
 									debian_instance_id = awsOps.getEC2Metadata("instance-id")
+									miscOps.callScriptOnServer()
 								}
-								callScriptOnServer()
 							}
 							post {
 								failure {
@@ -51,8 +51,8 @@ pipeline {
 								script {
 									if (env.CHANGE_ID) { pullRequest.createStatus(status: "pending", context: "setup-scripts/debian10", description: "Installing SimpleRisk through URL...", targetUrl: "$BUILD_URL") }
 									debian_instance_id = awsOps.getEC2Metadata("instance-id")
+									miscOps.callScriptFromURL("$script_commit")
 								}
-								callScriptFromURL("$script_commit")
 							}
 							post {
 								success {
@@ -84,9 +84,9 @@ pipeline {
 								script {
 									if (env.CHANGE_ID) { pullRequest.createStatus(status: "pending", context: "setup-scripts/ubuntu18", description: "Installing SimpleRisk through script on server...", targetUrl: "$BUILD_URL") }
 									u18_instance_id = awsOps.getEC2Metadata("instance-id")
+								    sh "sleep 2m"
+								    miscOps.callScriptOnServer()
 								}
-								sh "sleep 2m"
-								callScriptOnServer()
 							}
 							post {
 								failure {
@@ -109,9 +109,9 @@ pipeline {
 								script {
 									if (env.CHANGE_ID) { pullRequest.createStatus(status: "pending", context: "setup-scripts/ubuntu18", description: "Installing SimpleRisk through URL...", targetUrl: "$BUILD_URL") }
 									u18_instance_id = awsOps.getEC2Metadata("instance-id")
+									sh "sleep 2m"
+									miscOps.callScriptFromURL("$script_commit")
 								}
-								sh "sleep 2m"
-								callScriptFromURL("$script_commit")
 							}
 							post {
 								success {
@@ -143,8 +143,8 @@ pipeline {
 								script {
 									if (env.CHANGE_ID) { pullRequest.createStatus(status: "pending", context: "setup-scripts/ubuntu20", description: "Installing SimpleRisk through script on server...", targetUrl: "$BUILD_URL") }
 									u20_instance_id = awsOps.getEC2Metadata("instance-id")
+									miscOps.callScriptOnServer()
 								}
-								callScriptOnServer()
 							}
 							post {
 								failure {
@@ -167,8 +167,8 @@ pipeline {
 								script {
 									if (env.CHANGE_ID) { pullRequest.createStatus(status: "pending", context: "setup-scripts/ubuntu20", description: "Installing SimpleRisk through URL...", targetUrl: "$BUILD_URL") }
 									u20_instance_id = awsOps.getEC2Metadata("instance-id")
+									miscOps.callScriptFromURL("$script_commit")
 								}
-								callScriptFromURL("$script_commit")
 							}
 							post {
 								success {
@@ -200,8 +200,8 @@ pipeline {
 								script {
 									if (env.CHANGE_ID) { pullRequest.createStatus(status: "pending", context: "setup-scripts/sles12", description: "Installing SimpleRisk through script on server...", targetUrl: "$BUILD_URL") }
 									sles12_instance_id = awsOps.getEC2Metadata("instance-id")
+									miscOps.callScriptOnServer()
 								}
-								callScriptOnServer()
 							}
 							post {
 								failure {
@@ -224,8 +224,8 @@ pipeline {
 								script {
 									if (env.CHANGE_ID) { pullRequest.createStatus(status: "pending", context: "setup-scripts/sles12", description: "Installing SimpleRisk through URL...", targetUrl: "$BUILD_URL") }
 									sles12_instance_id = awsOps.getEC2Metadata("instance-id")
+									miscOps.callScriptFromURL("$script_commit")
 								}
-								callScriptFromURL("$script_commit")
 							}
 							post {
 								success {
@@ -257,8 +257,8 @@ pipeline {
 								script {
 									if (env.CHANGE_ID) { pullRequest.createStatus(status: "pending", context: "setup-scripts/sles15", description: "Installing SimpleRisk through script on server...", targetUrl: "$BUILD_URL") }
 									sles15_instance_id = awsOps.getEC2Metadata("instance-id")
+									miscOps.callScriptOnServer()
 								}
-								callScriptOnServer()
 							}
 							post {
 								failure {
@@ -281,8 +281,8 @@ pipeline {
 								script {
 									if (env.CHANGE_ID) { pullRequest.createStatus(status: "pending", context: "setup-scripts/sles15", description: "Installing SimpleRisk through URL...", targetUrl: "$BUILD_URL") }
 									sles15_instance_id = awsOps.getEC2Metadata("instance-id")
+									miscOps.callScriptFromURL("$script_commit")
 								}
-								callScriptFromURL("$script_commit")
 							}
 							post {
 								success {
@@ -314,8 +314,8 @@ pipeline {
 								script {
 									if (env.CHANGE_ID) { pullRequest.createStatus(status: "pending", context: "setup-scripts/rhel8", description: "Installing SimpleRisk through script on server...", targetUrl: "$BUILD_URL") }
 									rhel_instance_id = awsOps.getEC2Metadata("instance-id")
+									miscOps.callScriptOnServer()
 								}
-								callScriptOnServer()
 							}
 							post {
 								failure {
@@ -338,8 +338,8 @@ pipeline {
 								script {
 									if (env.CHANGE_ID) { pullRequest.createStatus(status: "pending", context: "setup-scripts/rhel8", description: "Installing SimpleRisk through URL...", targetUrl: "$BUILD_URL") }
 									rhel_instance_id = awsOps.getEC2Metadata("instance-id")
+									miscOps.callScriptFromURL("$script_commit")
 								}
-								callScriptFromURL("$script_commit")
 							}
 							post {
 								success {
@@ -371,8 +371,8 @@ pipeline {
 								script {
 									if (env.CHANGE_ID) { pullRequest.createStatus(status: "pending", context: "setup-scripts/centos7", description: "Installing SimpleRisk through script on server...", targetUrl: "$BUILD_URL") }
 									centos_instance_id = awsOps.getEC2Metadata("instance-id")
+									miscOps.callScriptOnServer()
 								}
-								callScriptOnServer()
 							}
 							post {
 								failure {
@@ -395,8 +395,8 @@ pipeline {
 								script {
 									if (env.CHANGE_ID) { pullRequest.createStatus(status: "pending", context: "setup-scripts/centos7", description: "Installing SimpleRisk through URL...", targetUrl: "$BUILD_URL") }
 									centos_instance_id = awsOps.getEC2Metadata("instance-id")
+									miscOps.callScriptFromURL("$script_commit")
 								}
-								callScriptFromURL("$script_commit")
 							}
 							post {
 								success {
@@ -428,18 +428,4 @@ pipeline {
 			}
 		}
 	}
-}
-
-void callScriptFromURL(String commit_ref) {
-	sh "curl -sL https://raw.githubusercontent.com/simplerisk/setup-scripts/$commit_ref/simplerisk-setup.sh | sudo bash -s -- -n -d"
-	validateStatusCode()
-}
-
-void callScriptOnServer() {
-	sh "sudo ./simplerisk-setup.sh -n -d"
-	validateStatusCode()
-}
-
-void validateStatusCode(String urlToCheck="https://localhost") {
-	sh "[ \"\$(curl -s -o /dev/null -w '%{http_code}' -k $urlToCheck)\" = \"200\" ] && exit 0 || exit 1"
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,16 +1,16 @@
+@Library('simplerisk@STABLE') _
+
 pipeline {
 	agent none
 	stages {
 		stage("Initializing Common Variables") {
 			agent { label "terminator" }
 			steps {
-				script {
-					committer_email = getCommitterEmail()
-				}
+				script { committer_email = gitOps.getCommitterEmail() }
 			}
 			post {
-				failure {
-					sendErrorEmail("${env.STAGE_NAME}", "${committer_email}")
+				failure { 
+					script { emailOps.sendErrorEmail("${env.STAGE_NAME}", "${committer_email}") }
 				}
 			}
 		}
@@ -19,69 +19,55 @@ pipeline {
 				stage("Debian 10") {
 					stages {
 						stage("Script On Server") {
-							agent {
-								label "debian10"
-							}
+							agent { label "debian10" }
 							steps {
 								script {
-									if (env.CHANGE_ID) {
-										pullRequest.createStatus(status: "pending", context: "setup-scripts/debian10", description: "Installing SimpleRisk through script on server...", targetUrl: "$BUILD_URL")
-									}
-									debian_instance_id = getInstanceId()
+									if (env.CHANGE_ID) { pullRequest.createStatus(status: "pending", context: "setup-scripts/debian10", description: "Installing SimpleRisk through script on server...", targetUrl: "$BUILD_URL") }
+									debian_instance_id = awsOps.getEC2Metadata("instance-id")
 								}
 								callScriptOnServer()
 							}
 							post {
 								failure {
 									script {
-										if (env.CHANGE_ID) {
-											pullRequest.createStatus(status: "failure", context: "setup-scripts/debian10", description: "Couldn't install SimpleRisk through script on server.", targetUrl: "$BUILD_URL")
-											sendErrorEmail("debian_10/${env.STAGE_NAME}", "${committer_email}")
-										}
+										if (env.CHANGE_ID) { pullRequest.createStatus(status: "failure", context: "setup-scripts/debian10", description: "Couldn't install SimpleRisk through script on server.", targetUrl: "$BUILD_URL") }
+										emailOps.sendErrorEmail("debian_10/${env.STAGE_NAME}", "${committer_email}")
 									}
 								}
 								aborted {
-									terminateInstance("${debian_instance_id}", "us-east-1")
+									script { awsOps.terminateInstance("${debian_instance_id}", "us-east-1") }
 								}
 								cleanup {
-									terminateInstance("${debian_instance_id}", "us-east-1")
+									script { awsOps.terminateInstance("${debian_instance_id}", "us-east-1") }
 								}
 							}
 						}
 						stage("Through Web URL") {
-							agent {
-								label "debian10"
-							}
+							agent { label "debian10" }
 							steps {
 								script {
-									if (env.CHANGE_ID) {
-										pullRequest.createStatus(status: "pending", context: "setup-scripts/debian10", description: "Installing SimpleRisk through URL...", targetUrl: "$BUILD_URL")
-									}
-									debian_instance_id = getInstanceId()
+									if (env.CHANGE_ID) { pullRequest.createStatus(status: "pending", context: "setup-scripts/debian10", description: "Installing SimpleRisk through URL...", targetUrl: "$BUILD_URL") }
+									debian_instance_id = awsOps.getEC2Metadata("instance-id")
 								}
 								callScriptFromURL()
 							}
 							post {
 								success {
 									script {
-										if (env.CHANGE_ID) {
-											pullRequest.createStatus(status: "success", context: "setup-scripts/debian10", description: "SimpleRisk installed successfully.", targetUrl: "$BUILD_URL")
-										}
+										if (env.CHANGE_ID) { pullRequest.createStatus(status: "success", context: "setup-scripts/debian10", description: "SimpleRisk installed successfully.", targetUrl: "$BUILD_URL") }
 									}
 								}
 								failure {
 									script {
-										if (env.CHANGE_ID) {
-											pullRequest.createStatus(status: "failure", context: "setup-scripts/debian10", description: "Couldn't install SimpleRisk through URL.", targetUrl: "$BUILD_URL")
-											sendErrorEmail("debian_10/${env.STAGE_NAME}", "${committer_email}")
-										}
+										if (env.CHANGE_ID) { pullRequest.createStatus(status: "failure", context: "setup-scripts/debian10", description: "Couldn't install SimpleRisk through URL.", targetUrl: "$BUILD_URL") }
+										emailOps.sendErrorEmail("debian_10/${env.STAGE_NAME}", "${committer_email}")
 									}
 								}
 								aborted {
-									terminateInstance("${debian_instance_id}", "us-east-1")
+									script { awsOps.terminateInstance("${debian_instance_id}", "us-east-1") }
 								}
 								cleanup {
-									terminateInstance("${debian_instance_id}", "us-east-1")
+									script { awsOps.terminateInstance("${debian_instance_id}", "us-east-1") }
 								}
 							}
 						}
@@ -90,15 +76,11 @@ pipeline {
 				stage("Ubuntu 18.04") {
 					stages {
 						stage("Script On Server") {
-							agent {
-								label "ubuntu18"
-							}
+							agent { label "ubuntu18" }
 							steps {
 								script {
-									if (env.CHANGE_ID) {
-										pullRequest.createStatus(status: "pending", context: "setup-scripts/ubuntu18", description: "Installing SimpleRisk through script on server...", targetUrl: "$BUILD_URL")
-									}
-									u18_instance_id = getInstanceId()
+									if (env.CHANGE_ID) { pullRequest.createStatus(status: "pending", context: "setup-scripts/ubuntu18", description: "Installing SimpleRisk through script on server...", targetUrl: "$BUILD_URL") }
+									u18_instance_id = awsOps.getEC2Metadata("instance-id")
 								}
 								sh "sleep 2m"
 								callScriptOnServer()
@@ -106,30 +88,24 @@ pipeline {
 							post {
 								failure {
 									script {
-										if (env.CHANGE_ID) {
-											pullRequest.createStatus(status: "failure", context: "setup-scripts/ubuntu18", description: "Couldn't install SimpleRisk through script on server.", targetUrl: "$BUILD_URL")
-											sendErrorEmail("ubuntu_1804/${env.STAGE_NAME}", "${committer_email}")
-										}
+										if (env.CHANGE_ID) { pullRequest.createStatus(status: "failure", context: "setup-scripts/ubuntu18", description: "Couldn't install SimpleRisk through script on server.", targetUrl: "$BUILD_URL") }
+										emailOps.sendErrorEmail("ubuntu_1804/${env.STAGE_NAME}", "${committer_email}")
 									}
 								}
 								aborted {
-									terminateInstance("${u18_instance_id}", "us-east-1")
+									script { awsOps.terminateInstance("${u18_instance_id}", "us-east-1") }
 								}
 								cleanup {
-									terminateInstance("${u18_instance_id}", "us-east-1")
+									script { awsOps.terminateInstance("${u18_instance_id}", "us-east-1") }
 								}
 							}
 						}
 						stage("Through Web URL") {
-							agent {
-								label "ubuntu18"
-							}
+							agent { label "ubuntu18" }
 							steps {
 								script {
-									if (env.CHANGE_ID) {
-										pullRequest.createStatus(status: "pending", context: "setup-scripts/ubuntu18", description: "Installing SimpleRisk through URL...", targetUrl: "$BUILD_URL")
-									}
-									u18_instance_id = getInstanceId()
+									if (env.CHANGE_ID) { pullRequest.createStatus(status: "pending", context: "setup-scripts/ubuntu18", description: "Installing SimpleRisk through URL...", targetUrl: "$BUILD_URL") }
+									u18_instance_id = awsOps.getEC2Metadata("instance-id")
 								}
 								sh "sleep 2m"
 								callScriptFromURL()
@@ -137,24 +113,20 @@ pipeline {
 							post {
 								success {
 									script {
-										if (env.CHANGE_ID) {
-											pullRequest.createStatus(status: "success", context: "setup-scripts/ubuntu18", description: "SimpleRisk installed successfully.", targetUrl: "$BUILD_URL")
-										}
+										if (env.CHANGE_ID) { pullRequest.createStatus(status: "success", context: "setup-scripts/ubuntu18", description: "SimpleRisk installed successfully.", targetUrl: "$BUILD_URL") }
 									}
 								}
 								failure {
 									script {
-										if (env.CHANGE_ID) {
-											pullRequest.createStatus(status: "failure", context: "setup-scripts/ubuntu18", description: "Couldn't install SimpleRisk through URL.", targetUrl: "$BUILD_URL")
-											sendErrorEmail("ubuntu_1804/${env.STAGE_NAME}", "${committer_email}")
-										}
+										if (env.CHANGE_ID) { pullRequest.createStatus(status: "failure", context: "setup-scripts/ubuntu18", description: "Couldn't install SimpleRisk through URL.", targetUrl: "$BUILD_URL") }
+										emailOps.sendErrorEmail("ubuntu_1804/${env.STAGE_NAME}", "${committer_email}")
 									}
 								}
 								aborted {
-									terminateInstance("${u18_instance_id}", "us-east-1")
+									script { awsOps.terminateInstance("${u18_instance_id}", "us-east-1") }
 								}
 								cleanup {
-									terminateInstance("${u18_instance_id}", "us-east-1")
+									script { awsOps.terminateInstance("${u18_instance_id}", "us-east-1") }
 								}
 							}
 						}
@@ -163,69 +135,55 @@ pipeline {
 				stage('Ubuntu 20.04') {
 					stages {
 						stage('Script On Server') {
-							agent {
-								label 'ubuntu20'
-							}
+							agent { label 'ubuntu20' }
 							steps {
 								script {
-									if (env.CHANGE_ID) {
-										pullRequest.createStatus(status: "pending", context: "setup-scripts/ubuntu20", description: "Installing SimpleRisk through script on server...", targetUrl: "$BUILD_URL")
-									}
-									u20_instance_id = getInstanceId()
+									if (env.CHANGE_ID) { pullRequest.createStatus(status: "pending", context: "setup-scripts/ubuntu20", description: "Installing SimpleRisk through script on server...", targetUrl: "$BUILD_URL") }
+									u20_instance_id = awsOps.getEC2Metadata("instance-id")
 								}
 								callScriptOnServer()
 							}
 							post {
 								failure {
 									script {
-										if (env.CHANGE_ID) {
-											pullRequest.createStatus(status: "failure", context: "setup-scripts/ubuntu20", description: "Couldn't install SimpleRisk through script on server.", targetUrl: "$BUILD_URL")
-											sendErrorEmail("ubuntu_2004/${env.STAGE_NAME}", "${committer_email}")
-										}
+										if (env.CHANGE_ID) { pullRequest.createStatus(status: "failure", context: "setup-scripts/ubuntu20", description: "Couldn't install SimpleRisk through script on server.", targetUrl: "$BUILD_URL") }
+										emailOps.sendErrorEmail("ubuntu_2004/${env.STAGE_NAME}", "${committer_email}")
 									}
 								}
 								aborted {
-									terminateInstance("${u20_instance_id}", "us-east-1")
+									script { awsOps.terminateInstance("${u20_instance_id}", "us-east-1") }
 								}
 								cleanup {
-									terminateInstance("${u20_instance_id}", "us-east-1")
+									script { awsOps.terminateInstance("${u20_instance_id}", "us-east-1") }
 								}
 							}
 						}
 						stage('Through Web URL') {
-							agent {
-								label 'ubuntu20'
-							}
+							agent { label 'ubuntu20' }
 							steps {
 								script {
-									if (env.CHANGE_ID) {
-										pullRequest.createStatus(status: "pending", context: "setup-scripts/ubuntu20", description: "Installing SimpleRisk through URL...", targetUrl: "$BUILD_URL")
-									}
-									u20_instance_id = getInstanceId()
+									if (env.CHANGE_ID) { pullRequest.createStatus(status: "pending", context: "setup-scripts/ubuntu20", description: "Installing SimpleRisk through URL...", targetUrl: "$BUILD_URL") }
+									u20_instance_id = awsOps.getEC2Metadata("instance-id")
 								}
 								callScriptFromURL()
 							}
 							post {
 								success {
 									script {
-										if (env.CHANGE_ID) {
-											pullRequest.createStatus(status: "success", context: "setup-scripts/ubuntu20", description: "SimpleRisk installed successfully.", targetUrl: "$BUILD_URL")
-										}
+										if (env.CHANGE_ID) { pullRequest.createStatus(status: "success", context: "setup-scripts/ubuntu20", description: "SimpleRisk installed successfully.", targetUrl: "$BUILD_URL") }
 									}
 								}
 								failure {
 									script {
-										if (env.CHANGE_ID) {
-											pullRequest.createStatus(status: "failure", context: "setup-scripts/ubuntu20", description: "Couldn't install SimpleRisk through URL.", targetUrl: "$BUILD_URL")
-											sendErrorEmail("ubuntu_2004/${env.STAGE_NAME}", "${committer_email}")
-										}
+										if (env.CHANGE_ID) { pullRequest.createStatus(status: "failure", context: "setup-scripts/ubuntu20", description: "Couldn't install SimpleRisk through URL.", targetUrl: "$BUILD_URL") }
+										emailOps.sendErrorEmail("ubuntu_2004/${env.STAGE_NAME}", "${committer_email}")
 									}
 								}
 								aborted {
-									terminateInstance("${u20_instance_id}", "us-east-1")
+									script { awsOps.terminateInstance("${u20_instance_id}", "us-east-1") }
 								}
 								cleanup {
-									terminateInstance("${u20_instance_id}", "us-east-1")
+									script { awsOps.terminateInstance("${u20_instance_id}", "us-east-1") }
 								}
 							}
 						}
@@ -234,69 +192,55 @@ pipeline {
 				stage('SLES 12') {
 					stages {
 						stage('Script On Server') {
-							agent {
-								label 'sles12'
-							}
+							agent { label 'sles12' }
 							steps {
 								script {
-									if (env.CHANGE_ID) {
-										pullRequest.createStatus(status: "pending", context: "setup-scripts/sles12", description: "Installing SimpleRisk through script on server...", targetUrl: "$BUILD_URL")
-									}
-									sles12_instance_id = getInstanceId()
+									if (env.CHANGE_ID) { pullRequest.createStatus(status: "pending", context: "setup-scripts/sles12", description: "Installing SimpleRisk through script on server...", targetUrl: "$BUILD_URL") }
+									sles12_instance_id = awsOps.getEC2Metadata("instance-id")
 								}
 								callScriptOnServer()
 							}
 							post {
 								failure {
 									script {
-										if (env.CHANGE_ID) {
-											pullRequest.createStatus(status: "failure", context: "setup-scripts/sles12", description: "Couldn't install SimpleRisk through script on server.", targetUrl: "$BUILD_URL")
-											sendErrorEmail("sles_12/${env.STAGE_NAME}", "${committer_email}")
-										}
+										if (env.CHANGE_ID) { pullRequest.createStatus(status: "failure", context: "setup-scripts/sles12", description: "Couldn't install SimpleRisk through script on server.", targetUrl: "$BUILD_URL") }
+										emailOps.sendErrorEmail("sles_12/${env.STAGE_NAME}", "${committer_email}")
 									}
 								}
 								aborted {
-									terminateInstance("${sles12_instance_id}", "us-east-1")
+									script { awsOps.terminateInstance("${sles12_instance_id}", "us-east-1") }
 								}
 								cleanup {
-									terminateInstance("${sles12_instance_id}", "us-east-1")
+									script { awsOps.terminateInstance("${sles12_instance_id}", "us-east-1") }
 								}
 							}
 						}
 						stage('Through Web URL') {
-							agent {
-								label 'sles12'
-							}
+							agent { label 'sles12' }
 							steps {
 								script {
-									if (env.CHANGE_ID) {
-										pullRequest.createStatus(status: "pending", context: "setup-scripts/sles12", description: "Installing SimpleRisk through URL...", targetUrl: "$BUILD_URL")
-									}
-									sles12_instance_id = getInstanceId()
+									if (env.CHANGE_ID) { pullRequest.createStatus(status: "pending", context: "setup-scripts/sles12", description: "Installing SimpleRisk through URL...", targetUrl: "$BUILD_URL") }
+									sles12_instance_id = awsOps.getEC2Metadata("instance-id")
 								}
 								callScriptFromURL()
 							}
 							post {
 								success {
 									script {
-										if (env.CHANGE_ID) {
-											pullRequest.createStatus(status: "success", context: "setup-scripts/sles12", description: "SimpleRisk installed successfully.", targetUrl: "$BUILD_URL")
-										}
+										if (env.CHANGE_ID) { pullRequest.createStatus(status: "success", context: "setup-scripts/sles12", description: "SimpleRisk installed successfully.", targetUrl: "$BUILD_URL") }
 									}
 								}
 								failure {
 									script {
-										if (env.CHANGE_ID) {
-											pullRequest.createStatus(status: "failure", context: "setup-scripts/sles12", description: "Couldn't install SimpleRisk through URL.", targetUrl: "$BUILD_URL")
-											sendErrorEmail("sles_12/${env.STAGE_NAME}", "${committer_email}")
-										}
+										if (env.CHANGE_ID) { pullRequest.createStatus(status: "failure", context: "setup-scripts/sles12", description: "Couldn't install SimpleRisk through URL.", targetUrl: "$BUILD_URL") }
+										emailOps.sendErrorEmail("sles_12/${env.STAGE_NAME}", "${committer_email}")
 									}
 								}
 								aborted {
-									terminateInstance("${sles12_instance_id}", "us-east-1")
+									script { awsOps.terminateInstance("${sles12_instance_id}", "us-east-1") }
 								}
 								cleanup {
-									terminateInstance("${sles12_instance_id}", "us-east-1")
+									script { awsOps.terminateInstance("${sles12_instance_id}", "us-east-1") }
 								}
 							}
 						}
@@ -305,69 +249,55 @@ pipeline {
 				stage('SLES 15') {
 					stages {
 						stage('Script On Server') {
-							agent {
-								label 'sles15'
-							}
+							agent { label 'sles15' }
 							steps {
 								script {
-									if (env.CHANGE_ID) {
-										pullRequest.createStatus(status: "pending", context: "setup-scripts/sles15", description: "Installing SimpleRisk through script on server...", targetUrl: "$BUILD_URL")
-									}
-									sles15_instance_id = getInstanceId()
+									if (env.CHANGE_ID) { pullRequest.createStatus(status: "pending", context: "setup-scripts/sles15", description: "Installing SimpleRisk through script on server...", targetUrl: "$BUILD_URL") }
+									sles15_instance_id = awsOps.getEC2Metadata("instance-id")
 								}
 								callScriptOnServer()
 							}
 							post {
 								failure {
 									script {
-										if (env.CHANGE_ID) {
-											pullRequest.createStatus(status: "failure", context: "setup-scripts/sles15", description: "Couldn't install SimpleRisk through script on server.", targetUrl: "$BUILD_URL")
-											sendErrorEmail("sles_15/${env.STAGE_NAME}", "${committer_email}")
-										}
+										if (env.CHANGE_ID) { pullRequest.createStatus(status: "failure", context: "setup-scripts/sles15", description: "Couldn't install SimpleRisk through script on server.", targetUrl: "$BUILD_URL") }
+										emailOps.sendErrorEmail("sles_15/${env.STAGE_NAME}", "${committer_email}")
 									}
 								}
 								aborted {
-									terminateInstance("${sles15_instance_id}", "us-east-1")
+									script { awsOps.terminateInstance("${sles15_instance_id}", "us-east-1") }
 								}
 								cleanup {
-									terminateInstance("${sles15_instance_id}", "us-east-1")
+									script { awsOps.terminateInstance("${sles15_instance_id}", "us-east-1") }
 								}
 							}
 						}
 						stage('Through Web URL') {
-							agent {
-								label 'sles15'
-							}
+							agent { label 'sles15' }
 							steps {
 								script {
-									if (env.CHANGE_ID) {
-										pullRequest.createStatus(status: "pending", context: "setup-scripts/sles15", description: "Installing SimpleRisk through URL...", targetUrl: "$BUILD_URL")
-									}
-									sles15_instance_id = getInstanceId()
+									if (env.CHANGE_ID) { pullRequest.createStatus(status: "pending", context: "setup-scripts/sles15", description: "Installing SimpleRisk through URL...", targetUrl: "$BUILD_URL") }
+									sles15_instance_id = awsOps.getEC2Metadata("instance-id")
 								}
 								callScriptFromURL()
 							}
 							post {
 								success {
 									script {
-										if (env.CHANGE_ID) {
-											pullRequest.createStatus(status: "success", context: "setup-scripts/sles15", description: "SimpleRisk installed successfully.", targetUrl: "$BUILD_URL")
-										}
+										if (env.CHANGE_ID) { pullRequest.createStatus(status: "success", context: "setup-scripts/sles15", description: "SimpleRisk installed successfully.", targetUrl: "$BUILD_URL") }
 									}
 								}
 								failure {
 									script {
-										if (env.CHANGE_ID) {
-											pullRequest.createStatus(status: "failure", context: "setup-scripts/sles15", description: "Couldn't install SimpleRisk through URL.", targetUrl: "$BUILD_URL")
-											sendErrorEmail("sles_15/${env.STAGE_NAME}", "${committer_email}")
-										}
+										if (env.CHANGE_ID) { pullRequest.createStatus(status: "failure", context: "setup-scripts/sles15", description: "Couldn't install SimpleRisk through URL.", targetUrl: "$BUILD_URL") }
+										emailOps.sendErrorEmail("sles_15/${env.STAGE_NAME}", "${committer_email}")
 									}
 								}
 								aborted {
-									terminateInstance("${sles15_instance_id}", "us-east-1")
+									script { awsOps.terminateInstance("${sles15_instance_id}", "us-east-1") }
 								}
 								cleanup {
-									terminateInstance("${sles15_instance_id}", "us-east-1")
+									script { awsOps.terminateInstance("${sles15_instance_id}", "us-east-1") }
 								}
 							}
 						}
@@ -376,69 +306,55 @@ pipeline {
 				stage('RHEL 8') {
 					stages {
 						stage('Script On Server') {
-							agent {
-								label 'rhel8'
-							}
+							agent { label 'rhel8' }
 							steps {
 								script {
-									if (env.CHANGE_ID) {
-										pullRequest.createStatus(status: "pending", context: "setup-scripts/rhel8", description: "Installing SimpleRisk through script on server...", targetUrl: "$BUILD_URL")
-									}
-									rhel_instance_id = getInstanceId()
+									if (env.CHANGE_ID) { pullRequest.createStatus(status: "pending", context: "setup-scripts/rhel8", description: "Installing SimpleRisk through script on server...", targetUrl: "$BUILD_URL") }
+									rhel_instance_id = awsOps.getEC2Metadata("instance-id")
 								}
 								callScriptOnServer()
 							}
 							post {
 								failure {
 									script {
-										if (env.CHANGE_ID) {
-											pullRequest.createStatus(status: "failure", context: "setup-scripts/rhel8", description: "Couldn't install SimpleRisk through script on server.", targetUrl: "$BUILD_URL")
-											sendErrorEmail("rhel_8/${env.STAGE_NAME}", "${committer_email}")
-										}
+										if (env.CHANGE_ID) { pullRequest.createStatus(status: "failure", context: "setup-scripts/rhel8", description: "Couldn't install SimpleRisk through script on server.", targetUrl: "$BUILD_URL") }
+										emailOps.sendErrorEmail("rhel_8/${env.STAGE_NAME}", "${committer_email}")
 									}
 								}
 								aborted {
-									terminateInstance("${rhel_instance_id}", "us-east-1")
+									script { awsOps.terminateInstance("${rhel_instance_id}", "us-east-1") }
 								}
 								cleanup {
-									terminateInstance("${rhel_instance_id}", "us-east-1")
+									script { awsOps.terminateInstance("${rhel_instance_id}", "us-east-1") }
 								}
 							}
 						}
 						stage('Through Web URL') {
-							agent {
-								label 'rhel8'
-							}
+							agent { label 'rhel8' }
 							steps {
 								script {
-									if (env.CHANGE_ID) {
-										pullRequest.createStatus(status: "pending", context: "setup-scripts/rhel8", description: "Installing SimpleRisk through URL...", targetUrl: "$BUILD_URL")
-									}
-									rhel_instance_id = getInstanceId()
+									if (env.CHANGE_ID) { pullRequest.createStatus(status: "pending", context: "setup-scripts/rhel8", description: "Installing SimpleRisk through URL...", targetUrl: "$BUILD_URL") }
+									rhel_instance_id = awsOps.getEC2Metadata("instance-id")
 								}
 								callScriptFromURL()
 							}
 							post {
 								success {
 									script {
-										if (env.CHANGE_ID) {
-											pullRequest.createStatus(status: "success", context: "setup-scripts/rhel8", description: "SimpleRisk installed successfully.", targetUrl: "$BUILD_URL")
-										}
+										if (env.CHANGE_ID) { pullRequest.createStatus(status: "success", context: "setup-scripts/rhel8", description: "SimpleRisk installed successfully.", targetUrl: "$BUILD_URL") }
 									}
 								}
 								failure {
 									script {
-										if (env.CHANGE_ID) {
-											pullRequest.createStatus(status: "failure", context: "setup-scripts/rhel8", description: "Couldn't install SimpleRisk through URL.", targetUrl: "$BUILD_URL")
-											sendErrorEmail("rhel_8/${env.STAGE_NAME}", "${committer_email}")
-										}
+										if (env.CHANGE_ID) { pullRequest.createStatus(status: "failure", context: "setup-scripts/rhel8", description: "Couldn't install SimpleRisk through URL.", targetUrl: "$BUILD_URL") }
+										emailOps.sendErrorEmail("rhel_8/${env.STAGE_NAME}", "${committer_email}")
 									}
 								}
 								aborted {
-									terminateInstance("${rhel_instance_id}", "us-east-1")
+									script { awsOps.terminateInstance("${rhel_instance_id}", "us-east-1") }
 								}
 								cleanup {
-									terminateInstance("${rhel_instance_id}", "us-east-1")
+									script { awsOps.terminateInstance("${rhel_instance_id}", "us-east-1") }
 								}
 							}
 						}
@@ -447,69 +363,55 @@ pipeline {
 				stage('CentOS 7') {
 					stages {
 						stage('Script On Server') {
-							agent {
-								label 'centos7'
-							}
+							agent { label 'centos7' }
 							steps {
 								script {
-									if (env.CHANGE_ID) {
-										pullRequest.createStatus(status: "pending", context: "setup-scripts/centos7", description: "Installing SimpleRisk through script on server...", targetUrl: "$BUILD_URL")
-									}
-									centos_instance_id = getInstanceId()
+									if (env.CHANGE_ID) { pullRequest.createStatus(status: "pending", context: "setup-scripts/centos7", description: "Installing SimpleRisk through script on server...", targetUrl: "$BUILD_URL") }
+									centos_instance_id = awsOps.getEC2Metadata("instance-id")
 								}
 								callScriptOnServer()
 							}
 							post {
 								failure {
 									script {
-										if (env.CHANGE_ID) {
-											pullRequest.createStatus(status: "failure", context: "setup-scripts/centos7", description: "Couldn't install SimpleRisk through script on server.", targetUrl: "$BUILD_URL")
-											sendErrorEmail("centos_7/${env.STAGE_NAME}", "${committer_email}")
-										}
+										if (env.CHANGE_ID) { pullRequest.createStatus(status: "failure", context: "setup-scripts/centos7", description: "Couldn't install SimpleRisk through script on server.", targetUrl: "$BUILD_URL") }
+										emailOps.sendErrorEmail("centos_7/${env.STAGE_NAME}", "${committer_email}")
 									}
 								}
 								aborted {
-									terminateInstance("${centos_instance_id}", "us-east-1")
+									script { awsOps.terminateInstance("${centos_instance_id}", "us-east-1") }
 								}
 								cleanup {
-									terminateInstance("${centos_instance_id}", "us-east-1")
+									script { awsOps.terminateInstance("${centos_instance_id}", "us-east-1") }
 								}
 							}
 						}
 						stage('Through Web URL') {
-							agent {
-								label 'centos7'
-							}
+							agent { label 'centos7' }
 							steps {
 								script {
-									if (env.CHANGE_ID) {
-										pullRequest.createStatus(status: "pending", context: "setup-scripts/centos7", description: "Installing SimpleRisk through URL...", targetUrl: "$BUILD_URL")
-									}
-									centos_instance_id = getInstanceId()
+									if (env.CHANGE_ID) { pullRequest.createStatus(status: "pending", context: "setup-scripts/centos7", description: "Installing SimpleRisk through URL...", targetUrl: "$BUILD_URL") }
+									centos_instance_id = awsOps.getEC2Metadata("instance-id")
 								}
 								callScriptFromURL()
 							}
 							post {
 								success {
 									script {
-										if (env.CHANGE_ID) {
-											pullRequest.createStatus(status: "success", context: "setup-scripts/centos7", description: "SimpleRisk installed successfully.", targetUrl: "$BUILD_URL")
-										}
+										if (env.CHANGE_ID) { pullRequest.createStatus(status: "success", context: "setup-scripts/centos7", description: "SimpleRisk installed successfully.", targetUrl: "$BUILD_URL") }
 									}
 								}
 								failure {
 									script {
-										if (env.CHANGE_ID) {
-											pullRequest.createStatus(status: "failure", context: "setup-scripts/centos7", description: "Couldn't install SimpleRisk through URL.", targetUrl: "$BUILD_URL")
-											sendErrorEmail("centos_7/${env.STAGE_NAME}", "${committer_email}")
-										}
+										if (env.CHANGE_ID) { pullRequest.createStatus(status: "failure", context: "setup-scripts/centos7", description: "Couldn't install SimpleRisk through URL.", targetUrl: "$BUILD_URL") }
+										emailOps.sendErrorEmail("centos_7/${env.STAGE_NAME}", "${committer_email}")
 									}
 								}
 								aborted {
-									terminateInstance("${centos_instance_id}", "us-east-1")
+									script { awsOps.terminateInstance("${centos_instance_id}", "us-east-1") }
 								}
 								cleanup {
-									terminateInstance("${centos_instance_id}", "us-east-1")
+									script { awsOps.terminateInstance("${centos_instance_id}", "us-east-1") }
 								}
 							}
 						}
@@ -518,21 +420,13 @@ pipeline {
 			}
 			post {
 				success {
-					sendSuccessEmail("${committer_email}")
+					script { emailOps.sendSuccessEmail("${committer_email}") }
 				}
 			}
 		}
 	}
 }
 
-
-def getCommitterEmail() {
-	return sh(script: "git --no-pager show -s --format='%ae'", returnStdout: true).trim()
-}
-
-def getInstanceId() {
-	return sh(script: 'echo $(TOKEN=`curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600"` && curl -s -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/instance-id)', returnStdout: true).trim()
-}
 
 void callScriptFromURL() {
 	sh "curl -sL https://raw.githubusercontent.com/simplerisk/setup-scripts/${(env.CHANGE_ID != null ? pullRequest.head : env.BRANCH_NAME)}/simplerisk-setup.sh | sudo bash -s -- -n -d"
@@ -542,21 +436,6 @@ void callScriptFromURL() {
 void callScriptOnServer() {
 	sh "sudo ./simplerisk-setup.sh -n -d"
 	validateStatusCode()
-}
-
-
-void sendEmail(String message, String recipient) {
-        mail from: 'jenkins@simplerisk.com', to: """${recipient}""", bcc: '',  cc: 'pedro@simplerisk.com', replyTo: '',
-             subject: """${env.JOB_NAME} (Branch ${env.BRANCH_NAME}) - Build # ${env.BUILD_NUMBER} - ${currentBuild.currentResult}""",
-             body: "$message"
-}
-
-void sendErrorEmail(String stage, String recipient) {
-        sendEmail("""Job failed at stage \"${stage}\". Check console output at ${env.BUILD_URL} to view the results (The Blue Ocean option will provide the detailed execution flow).""", "$recipient")
-}
-
-void sendSuccessEmail(String recipient) {
-        sendEmail("""Check console output at ${env.BUILD_URL} to view the results (The Blue Ocean option will provide the detailed execution flow).""", "$recipient")
 }
 
 void suseRegisterCloudGuest() {
@@ -577,13 +456,6 @@ void ubuntuReconfiguredpkg() {
 		sudo rm -f /var/cache/apt/archives/lock
 		sudo dpkg --configure -a
 	'''
-}
-
-void terminateInstance(String instanceId, String region, Integer number=60) {
-	node("terminator") {
-		sh "aws ec2 terminate-instances --instance-ids $instanceId --region $region"
-		sh "sleep $number"
-	}
 }
 
 void validateStatusCode(String urlToCheck="https://localhost") {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,7 +41,7 @@ pipeline {
 									script { awsOps.terminateInstance("${debian_instance_id}") }
 								}
 								cleanup {
-									script { awsOps.terminateInstance("${debian_instance_id}", 60) }
+									script { awsOps.terminateInstance("${debian_instance_id}", true) }
 								}
 							}
 						}
@@ -99,7 +99,7 @@ pipeline {
 									script { awsOps.terminateInstance("${u18_instance_id}") }
 								}
 								cleanup {
-									script { awsOps.terminateInstance("${u18_instance_id}", 60) }
+									script { awsOps.terminateInstance("${u18_instance_id}", true) }
 								}
 							}
 						}
@@ -157,7 +157,7 @@ pipeline {
 									script { awsOps.terminateInstance("${u20_instance_id}") }
 								}
 								cleanup {
-									script { awsOps.terminateInstance("${u20_instance_id}", 60) }
+									script { awsOps.terminateInstance("${u20_instance_id}", true) }
 								}
 							}
 						}
@@ -214,7 +214,7 @@ pipeline {
 									script { awsOps.terminateInstance("${sles12_instance_id}") }
 								}
 								cleanup {
-									script { awsOps.terminateInstance("${sles12_instance_id}", 60) }
+									script { awsOps.terminateInstance("${sles12_instance_id}", true) }
 								}
 							}
 						}
@@ -271,7 +271,7 @@ pipeline {
 									script { awsOps.terminateInstance("${sles15_instance_id}") }
 								}
 								cleanup {
-									script { awsOps.terminateInstance("${sles15_instance_id}", 60) }
+									script { awsOps.terminateInstance("${sles15_instance_id}", true) }
 								}
 							}
 						}
@@ -328,7 +328,7 @@ pipeline {
 									script { awsOps.terminateInstance("${rhel_instance_id}") }
 								}
 								cleanup {
-									script { awsOps.terminateInstance("${rhel_instance_id}", 60) }
+									script { awsOps.terminateInstance("${rhel_instance_id}", true) }
 								}
 							}
 						}
@@ -385,7 +385,7 @@ pipeline {
 									script { awsOps.terminateInstance("${centos_instance_id}") }
 								}
 								cleanup {
-									script { awsOps.terminateInstance("${centos_instance_id}", 60) }
+									script { awsOps.terminateInstance("${centos_instance_id}", true) }
 								}
 							}
 						}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('simplerisk@STABLE') _
+@Library('simplerisk') _
 
 pipeline {
 	agent none


### PR DESCRIPTION
As there are too many common functions between Jenkinsfiles, I created a [shared libraries repository](https://github.com/simplerisk/jenkins-shared-libraries) where Jenkins first retrieve it and then, when a Jenkinsfile is read and executed, it will use functions from the shared libraries as long as it is specified on the header (`@Library('simplerisk') _`).