### PR TITLE
Remove CI-only flags from public script and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,10 @@ Run as root or insert `sudo -E` before `bash`:
 ```
 Script to set up SimpleRisk on a server.
 
-./simplerisk-setup [-d|--debug] [-n|--no-assistance] [-h|--help] [--validate-os-only]
+./simplerisk-setup [-d|--debug] [-n|--no-assistance] [-h|--help]
 
 Flags:
 -d|--debug:            Shows the output of the commands being run by this script
 -n|--no-assistance:    Runs the script in headless mode (will assume yes on anything)
--t|--testing:          Picks the current testing version
---validate-os-only:    Only validates if the current host (OS and version) are supported by the script. This option does not require running the script as superuser.
 -h|--help:             Shows instructions on how to use this script
 ```

--- a/simplerisk-setup.sh
+++ b/simplerisk-setup.sh
@@ -19,19 +19,12 @@ readonly MYSQL_GPG_KEY='B7B3B788A8D3785C' # Key taken from https://dev.mysql.com
 setup (){
 	validate_args "${@:1}"
 
-	# Check root unless you only want to validate if the script works on the host
-	if [ ! -v VALIDATE_ONLY ]; then
-		check_root
-	fi
-	# Ask user input unless it is on headless mode or validating if the script works
-	if [ ! -v HEADLESS ] && [ ! -v VALIDATE_ONLY ]; then
+	check_root
+	if [ ! -v HEADLESS ]; then
 		ask_user
 	fi
 	load_os_variables
 	validate_os_and_version
-	if [ -v VALIDATE_ONLY ]; then
-		exit 0
-	fi
 	perform_installation
 }
 
@@ -45,12 +38,6 @@ validate_args(){
 				shift;;
 			-d|--debug)
 				DEBUG=y
-				shift;;
-			-t|--testing)
-				TESTING=y
-				shift;;
-			--validate-os-only)
-				VALIDATE_ONLY=y
 				shift;;
 			-h|--help)
 				print_help
@@ -146,7 +133,7 @@ validate_os_and_version(){
 				if ! sudo suseconnect --list-extensions | grep -F "$php_module" | grep -q "Activated"; then
 					print_error_message "$php_module is not enabled on your subscription. Please enable it before running this installer."
 				fi
-				if [ ! -v HEADLESS ] && [ ! -v VALIDATE_ONLY ]; then
+				if [ ! -v HEADLESS ]; then
 					read -r -p 'Before continuing, SLES 15 does not have sendmail available. Proceed? [ Yes / (No) ]: ' answer < /dev/tty
 					case "${answer}" in
 						Yes|yes|Y|y ) SETUP_TYPE=suse;;
@@ -291,7 +278,7 @@ set_up_backup_cronjob() {
 }
 
 get_current_simplerisk_version() {
-	curl -sL "https://updates${TESTING:+-test}.simplerisk.com/releases.xml" | grep -oP '<release version=(.*)>' | head -n1 | cut -d '"' -f 2
+	curl -sL "https://updates.simplerisk.com/releases.xml" | grep -oP '<release version=(.*)>' | head -n1 | cut -d '"' -f 2
 }
 
 get_installed_php_version() {
@@ -312,14 +299,10 @@ print_help() {
 
 Script to set up SimpleRisk on a server.
 
-./simplerisk-setup [-d|--debug] [--yes] [-h|--help] [--validate-os-only]
+./simplerisk-setup [-d|--debug] [--yes] [-h|--help]
 
 Flags:
 -d|--debug:            Shows the output of the commands being run by this script
--t|--testing:          Picks the current testing version
---validate-os-only:    Only validates if the current host (OS and version) are supported
-                         by the script. This option does not require running the script
-			 as superuser.
 --yes:                 Will answer yes on every question (Use it carefully)
 -h|--help:             Shows instructions on how to use this script
 EOC


### PR DESCRIPTION
## Summary

- Removed `-t|--testing` flag (used internally to target the testing release URL)
- Removed `--validate-os-only` flag (used by Jenkins to verify OS support without installing)
- Removed all associated `VALIDATE_ONLY` guards from `setup()` and `validate_os_and_version()`
- Hardcoded release URL to `updates.simplerisk.com` (no more testing URL toggle)
- Updated `README.md` to remove both CI-only flags from the help section

## Why

These flags are for internal CI/Jenkins use only. Exposing them in the public repo creates a surface for malicious external contributions that could affect our testing infrastructure. Both flags remain fully intact in `setup-scripts-dev`.

## Test plan

- [ ] Verify `simplerisk-setup.sh --help` no longer shows `--testing` or `--validate-os-only`
- [ ] Verify normal installation flow still works (no `VALIDATE_ONLY` regressions)
- [ ] Confirm `updates.simplerisk.com` resolves correctly for production installs

🤖 Generated with [Claude Code](https://claude.com/claude-code)