### PR TITLE
Create /var/log/simplerisk/simplerisk.log with correct apache ownership

### DIFF
--- a/simplerisk-setup.sh
+++ b/simplerisk-setup.sh
@@ -337,6 +337,16 @@ set_up_backup_cronjob() {
 	exec_cmd "(crontab -l 2>/dev/null; echo '* * * * * $(which php) -f /var/www/simplerisk/cron/cron.php') | crontab -"
 }
 
+set_up_simplerisk_log() {
+	# $1 receives the apache user that should own the log directory and file
+	print_status 'Creating SimpleRisk log directory and file...'
+	run_cmd mkdir -p /var/log/simplerisk
+	run_cmd touch /var/log/simplerisk/simplerisk.log
+	run_cmd chown -R "${1}:" /var/log/simplerisk
+	run_cmd chmod 750 /var/log/simplerisk
+	run_cmd chmod 640 /var/log/simplerisk/simplerisk.log
+}
+
 get_current_simplerisk_version() {
 	curl -sL "https://updates${TESTING:+-test}.simplerisk.com/releases.xml" | grep -oP '<release version=(.*)>' | head -n1 | cut -d '"' -f 2
 }
@@ -505,6 +515,7 @@ setup_ubuntu_debian(){
 	set_php_settings "/etc/php/$php_version/apache2/php.ini"
 
 	set_up_simplerisk 'www-data' "${1}"
+	set_up_simplerisk_log 'www-data'
 
 	print_status 'Configuring Apache...'
 	run_cmd sed -i 's|\(/var/www/\)html|\1simplerisk|g' /etc/apache2/sites-enabled/000-default.conf
@@ -615,6 +626,7 @@ setup_centos_rhel(){
 	run_cmd dnf -y install sendmail sendmail-cf m4
 
 	set_up_simplerisk 'apache' "${1}"
+	set_up_simplerisk_log 'apache'
 
 	print_status 'Configuring Apache...'
 	run_cmd sed -i 's|#\?\(DocumentRoot "/var/www/\)html"|\1simplerisk"|' /etc/httpd/conf.d/ssl.conf
@@ -693,6 +705,7 @@ EOF
 		run_cmd setsebool -P "$permission=0"
 	done
 	run_cmd chcon -R -t httpd_sys_rw_content_t /var/www/simplerisk
+	run_cmd chcon -R -t httpd_log_t /var/log/simplerisk
 }
 
 setup_suse(){
@@ -809,6 +822,7 @@ EOF
 	done
 
 	set_up_simplerisk 'wwwrun' "${1}"
+	set_up_simplerisk_log 'wwwrun'
 
 	print_status 'Restarting Apache to load the new configuration...'
 	run_cmd systemctl restart apache2
@@ -860,6 +874,9 @@ uninstall_ubuntu_debian(){
 	print_status 'Removing SimpleRisk application files...'
 	run_cmd_nobail rm -rf /var/www/simplerisk
 
+	print_status 'Removing SimpleRisk log directory...'
+	run_cmd_nobail rm -rf /var/log/simplerisk
+
 	print_status 'Removing installed packages...'
 	exec_cmd_nobail "apt-get purge -y 'php*' 'libapache2-mod-php*' apache2 apache2-utils apache2-bin mysql-server mysql-client mysql-common sendmail sendmail-bin"
 	run_cmd_nobail apt-get autoremove -y
@@ -898,6 +915,9 @@ uninstall_centos_rhel(){
 
 	print_status 'Removing SimpleRisk application files...'
 	run_cmd_nobail rm -rf /var/www/simplerisk
+
+	print_status 'Removing SimpleRisk log directory...'
+	run_cmd_nobail rm -rf /var/log/simplerisk
 
 	print_status 'Removing SimpleRisk Apache virtual host config...'
 	run_cmd_nobail rm -f /etc/httpd/sites-enabled/simplerisk.conf
@@ -940,6 +960,9 @@ uninstall_suse(){
 
 	print_status 'Removing SimpleRisk application files...'
 	run_cmd_nobail rm -rf /var/www/simplerisk
+
+	print_status 'Removing SimpleRisk log directory...'
+	run_cmd_nobail rm -rf /var/log/simplerisk
 
 	print_status 'Removing SimpleRisk Apache virtual host and SSL config...'
 	run_cmd_nobail rm -f /etc/apache2/vhosts.d/simplerisk.conf


### PR DESCRIPTION
## Summary

- Adds a new `set_up_simplerisk_log` helper that creates `/var/log/simplerisk/` and `simplerisk.log`, then sets ownership and permissions using the OS-appropriate apache user
- Calls the helper from each OS setup function with the correct user: `www-data` (Debian/Ubuntu), `apache` (RHEL/CentOS), `wwwrun` (SUSE)
- Applies `httpd_log_t` SELinux context to `/var/log/simplerisk` on RHEL/CentOS installs
- All three uninstall functions now also remove `/var/log/simplerisk` during cleanup

## Permissions set

| Path | Mode |
|---|---|
| `/var/log/simplerisk/` | `750` (apache user owns, root group) |
| `/var/log/simplerisk/simplerisk.log` | `640` |

## Test plan

- [ ] Run setup on Ubuntu 22.04/24.x — verify `/var/log/simplerisk/simplerisk.log` exists, owned by `www-data`
- [ ] Run setup on RHEL/CentOS 9/10 — verify owned by `apache`, SELinux context is `httpd_log_t`
- [ ] Run setup on SLES 15.7 — verify owned by `wwwrun`
- [ ] Run `--uninstall` on each OS — verify `/var/log/simplerisk` is removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)